### PR TITLE
Address download_as_string() deprecation

### DIFF
--- a/berglas/resolver.py
+++ b/berglas/resolver.py
@@ -57,7 +57,7 @@ class Client:
             raise AutoException("missing kms key in secret metadata")
 
         key = blob.metadata[METADATA_KMS_KEY]
-        data = blob.download_as_string()
+        data = blob.download_as_bytes()
         parts = data.split(b":", maxsplit=1)
         if len(parts) < 2:
             raise AutoException("invalid ciphertext: not enough parts")


### PR DESCRIPTION
This addresses this deprecation error that is stopping the pytests from completing:
```
Blob.download_as_string() is deprecated and will be removed in future. Use Blob.download_as_bytes() instead.
```